### PR TITLE
Notify the end user if the serviceWorker is unavailable

### DIFF
--- a/webapp/src/dl/index.ts
+++ b/webapp/src/dl/index.ts
@@ -26,6 +26,12 @@ function cleanupKey(key: string) {
 async function run() {
   const loc = window.location;
   const rootUrl = loc.origin + loc.pathname.replace("/dl","/");
+
+  if (navigator.serviceWorker == null) {
+    alert('No serviceWorker available ! Please note the feature may not be available in private mode in Firefox');
+    loc.replace(rootUrl);
+    return;
+  }
   try {
     await navigator.serviceWorker.register('./sw.js', {'scope': '/v1/download/'});
   }

--- a/webapp/src/gui/index.ts
+++ b/webapp/src/gui/index.ts
@@ -33,8 +33,14 @@ app.route('/', uploadView);
 
 const mountProm = app.mount('body');
 
-// Register service worker
-navigator.serviceWorker.register('./sw.js', {'scope': '/v1/download/'});
+// Test if serviceWorker is available, the feature may not be available in private mode in FF
+// see https://developer.mozilla.org/en-US/docs/Web/API/Navigator/serviceWorker
+if (navigator.serviceWorker == null) {
+  console.log('[**] No serviceWorker available, maybe due to FF in private mode ?');
+} else {
+ // Register service worker
+ navigator.serviceWorker.register('./sw.js', {'scope': '/v1/download/'});
+}
 
 export default async () => {
   await mountProm;

--- a/webapp/src/gui/index.ts
+++ b/webapp/src/gui/index.ts
@@ -38,8 +38,8 @@ const mountProm = app.mount('body');
 if (navigator.serviceWorker == null) {
   console.log('[**] No serviceWorker available, maybe due to FF in private mode ?');
 } else {
- // Register service worker
- navigator.serviceWorker.register('./sw.js', {'scope': '/v1/download/'});
+  // Register service worker
+  navigator.serviceWorker.register('./sw.js', {'scope': '/v1/download/'});
 }
 
 export default async () => {


### PR DESCRIPTION
Hola o/
 
When sharing a file with someone using Firefox in private mode, the user may be redirected to the home page of the application, with no download available. This is due to `navigator.serviceWorker` being null, which triggers an exception and so redirects to webroot.

This fix just pops a msgbox to warn the user before being redirected.